### PR TITLE
fix: do not set any default settings metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,6 @@ var tar = require('tar-fs')
 var pump = require('pump')
 var path = require('path')
 
-var METADATA_DEFAULTS = {
-  dataset_id: 'mapeodata'
-}
-
 class Settings {
   constructor (userDataPath) {
     this.userDataPath = userDataPath
@@ -38,7 +34,7 @@ class Settings {
         return readJsonSync(path.join(this.defaultPath, type + '.json'))
       case 'metadata':
         var data = readJsonSync(path.join(this.defaultPath, type + '.json'))
-        return Object.assign({}, METADATA_DEFAULTS, data)
+        return data
       case 'translations':
         return readJsonSync(path.join(this.defaultPath, type + '.json'))
       default:


### PR DESCRIPTION
@gmaclennan identified an issue in the desktop app where returning the default metadata in the `getSettings` prevents important code paths from being executed under more specific circumstances: https://github.com/digidem/mapeo-desktop/blob/d7aab81c97bcec68dc1993efbf827ad0d4726618/src/main/user-config.js#L28-L29. The suggested fix is to remove any responsibility of providing a default value in this module and leave it for the consumers (e.g. desktop + mobile apps) to handle

The affected desktop application code already accounts for a falsy value and provides the same fallback (see [here](https://github.com/digidem/mapeo-desktop/blob/d7aab81c97bcec68dc1993efbf827ad0d4726618/src/main/ipc.js#L100) and [here](https://github.com/digidem/mapeo-desktop/blob/d7aab81c97bcec68dc1993efbf827ad0d4726618/src/main/ipc.js#L123)). The change in this PR thus should have little to no consequences on dependants

